### PR TITLE
Reverse order of slides in dashboard view

### DIFF
--- a/client/routes.js
+++ b/client/routes.js
@@ -2,7 +2,7 @@ Router.route("/", function() {
 	this.render("dashboard", {
 		data: function() {
 			return {
-				slides: slideshow.find({}),
+				slides: slideshow.find({}).fetch().reverse(),
 				history: history_log.find({}, {sort: {time:-1}}),
 				tagmode: tagmode.find({})
 			}


### PR DESCRIPTION
This is a slightly hacky solution to fix #74 . 

A more optimal solution would probably be something like:
```javascript
slides: slideshow.find({}, {sort: {$natural: -1}}),
```

But if I understand it correctly, Meteor uses Minimongo where `$natural` is an unsupported sort key. We could create another value in the slideshow collection schema, it seems like `createdAt` is a common attribute, we would then be able to sort by that. But we wouldn't have that information on existing slides.

What this solution does is fetching all matching documents in an array instead of returning a cursor. This is then reversed and used in the same `#forEach` in the dashboard view. Both arrays and cursors are supported in `#forEach`. So there is probably no practical difference with the amount of slides we have.