### PR TITLE
Edit name of a slide after creation

### DIFF
--- a/client/scripts/dashboard.js
+++ b/client/scripts/dashboard.js
@@ -132,7 +132,7 @@ Template.slide.events({
 		var tagstring = $("#tags" + this._id).val().trim()
 		var date =  new Date(Date.parse($("#expire" + this._id).val()))
 		//Get new name
-		var name = $("#name" + this._id).val()
+		var name = $("#name" + this._id).val().trim()
 		//Set new name to old if empty
 		if (name === "") name = obj_cp.name
 

--- a/client/scripts/dashboard.js
+++ b/client/scripts/dashboard.js
@@ -123,7 +123,7 @@ Template.slide.events({
 		var obj_cp = {}
 		shallow_copy(obj_cp, this)
 		history_log.insert({
-			action:"Updated tags/expiry",
+			action:"Updated name/tags/expiry",
 			by:Meteor.user().username,
 			time:Date.now(),
 			note:"obj represents the state of the slide before update",

--- a/client/scripts/dashboard.js
+++ b/client/scripts/dashboard.js
@@ -131,10 +131,15 @@ Template.slide.events({
 		})
 		var tagstring = $("#tags" + this._id).val().trim()
 		var date =  new Date(Date.parse($("#expire" + this._id).val()))
+		//Get new name
+		var name = $("#name" + this._id).val()
+		//Set new name to old if empty
+		if (name === "") name = obj_cp.name
+
 		if(date != "Invalid Date") {
-			slideshow.update({_id:this._id}, {$set: {expire: date, tags: tagstring.split(" ")}})
+			slideshow.update({_id:this._id}, {$set: {name: name, expire: date, tags: tagstring.split(" ")}})
 		} else {
-			slideshow.update({_id:this._id}, {$set: {expire: undefined, tags: tagstring.split(" ")}})
+			slideshow.update({_id:this._id}, {$set: {name: name, expire: undefined, tags: tagstring.split(" ")}})
 		}
 		Session.set("hazEdit", null)
 	}

--- a/client/views/slide.html
+++ b/client/views/slide.html
@@ -43,7 +43,11 @@
 			</div>
 			<div id="modal{{_id}}" class="modal">
 			    <div class="modal-content">
-			      	<span class="card-title">{{name}}</span>
+						<!-- <span class="card-title">{{name}}</span> -->
+							<div class="input-field">
+								<input id="name{{_id}}" value="{{name}}" type="text" name="name">
+								<label class="active" for="name">Name</label>
+							</div>
 			      	<div class="row">
 						<div class="input-field col s12 m6">
 							<input value="{{dateinput expire}}" id="expire{{_id}}" type="date" name="expire">


### PR DESCRIPTION
You can now edit the name of a slide after it is created.

Fixes: #66 