### PR TITLE
Add spacebar as a method for advancing slides on /slideshow/*

### DIFF
--- a/client/scripts/slideshow.js
+++ b/client/scripts/slideshow.js
@@ -20,8 +20,8 @@ Template.slideshow.events({
 	}
 })
 
-Template.slideshow.onCreated(() => {
-	$(document).on('keydown', (event) => {
+Template.slideshow.onCreated(function () {
+	$(document).on('keydown', function (event) {
 		if (event.key == " ") {
 			syncStream.emit("flip", "");
 		}


### PR DESCRIPTION
Implements 03f878647fc773cffe745e3cd118da24ea4a29ac, but without arrow functions

Co-authored-by: Herkarl <herkarlsson@gmail.com>