### PR TITLE
Implement error text warning that images of the wrong dimension might not display correctly

### DIFF
--- a/client/scripts/dashboard.js
+++ b/client/scripts/dashboard.js
@@ -70,7 +70,7 @@ Template.dashboard.events({
 			tags:$("#tags").val().split(" "),
 			createdBy: Meteor.user().username,
 			onlywhenfiltering: $(".hashtagonlyfilter").is(":checked")
-		};
+		}
 
 		var date = new Date(Date.parse($("#expire").val()));
 

--- a/client/scripts/uploader.js
+++ b/client/scripts/uploader.js
@@ -4,6 +4,7 @@ var is_correct_dimensions = function(url) {
 	p = $(img).ready(function () {
 		return { width: img.width, height: img.height }
 	})
+	var _ = p[0]['width'] // p[0] seems to need to be used at least once for it to give the right value in the case of a local image
 	return p[0]['width'] == 1920 && p[0]['height'] == 1080
 }
 

--- a/client/scripts/uploader.js
+++ b/client/scripts/uploader.js
@@ -51,12 +51,7 @@ Template.uploader.helpers({
 	uploading: function() {
 		return Session.get("is_loading") && Session.get("type") == "local img";
 	},
-	loginurl: getLoginUrl,
-
-	badDimensions: function () {
-		return Session.get(this._id + "badDimension") == "true";
-		// return false;
-	}
+	loginurl: getLoginUrl
 });
 
 Template.slide.helpers({

--- a/client/style.scss
+++ b/client/style.scss
@@ -167,6 +167,16 @@ iframe {
 	}
 }
 
+.image-error {
+
+	color: $red !important;
+	margin-top: 3px;
+	margin-bottom: 3px;
+	text-align: center;
+
+}
+
+
 .links {
 	display: none;
 	background: $light-gray;

--- a/client/views/page.html
+++ b/client/views/page.html
@@ -7,7 +7,7 @@
 			{{#if equals type "external img"}}
 				<div class="card-image">
 					<img src="{{link}}">
-					{{#if equals badDimensions true}}
+					{{#if badDimensions}}
 						<div class="image-error">
 							Image is not 1920x1080. It might not display as intended
 						</div>
@@ -17,7 +17,7 @@
 			{{#if equals type "local img"}}
 				<div class="card-image">
 					<img src="{{link}}">
-					{{#if equals badDimensions true}}
+					{{#if badDimensions}}
 						<div class="image-error">
 							Image is not 1920x1080. It might not display as intended
 						</div>

--- a/client/views/page.html
+++ b/client/views/page.html
@@ -7,11 +7,21 @@
 			{{#if equals type "external img"}}
 				<div class="card-image">
 					<img src="{{link}}">
+					{{#if equals badDimensions true}}
+						<div class="image-error">
+							Image is not 1920x1080. It might not display as intended
+						</div>
+					{{/if}}
 				</div>
 			{{/if}}
 			{{#if equals type "local img"}}
 				<div class="card-image">
 					<img src="{{link}}">
+					{{#if equals badDimensions true}}
+						<div class="image-error">
+							Image is not 1920x1080. It might not display as intended
+						</div>
+					{{/if}}
 				</div>
 			{{/if}}
 			{{#if equals type "website"}}

--- a/server/collections.js
+++ b/server/collections.js
@@ -48,8 +48,8 @@ history.allow({
 Meteor.methods({
 	setScreen: function(pageId, screenId) {
 		if (! Meteor.userId()) {
-			throw new Meteor.Error("not-authorized");
-			}
+			throw new Meteor.Error("not-authorized")
+		}
 
 		slideshow.update({"pages._id": pageId},
 			{$set: {"pages.$.screen": screenId}})

--- a/server/sampledata.js
+++ b/server/sampledata.js
@@ -16,6 +16,7 @@ Meteor.startup(function () {
 					"type":"external img",
 					"createdBy":"anlinn",
 					"screen":"1",
+					"badDimensions":true,
 					"link":"http://placekitten.com/1200/800"
 				}
 			]


### PR DESCRIPTION
When uploading images that are not 1920x1080 you get white bars around the picture when they are displayed on META-TV, which looks quite ugly.

I think this is a better solution than eg. scaling since that looks bad, and it is usually fairly easy to fix manually, and it gives the user more control on how the images looks.

I have tested this locally and it has worked for both external images and local images.

(also accidentally did some minor cleanup)